### PR TITLE
Increase line-height in `p` tags to improve legibility

### DIFF
--- a/Resources/styles.css
+++ b/Resources/styles.css
@@ -87,7 +87,7 @@ code {
 }
 
 p {
-  line-height: 1.4;
+  line-height: 1.5;
   margin-bottom: 0.5em;
 }
 


### PR DESCRIPTION
In paragraphs with heavy underlined links and monospace font insertions it almost feels as if line height is inconsistent between different lines. I'm pretty sure it isn't, but underlines and jumping font height give that illusion. Increasing the line height slightly reduces this effect, as paragraph text looks a bit less crowded then.

Before:

<img width="995" alt="Screenshot 2020-10-30 at 09 27 30" src="https://user-images.githubusercontent.com/112310/97688805-9b6b9b00-1a92-11eb-8af9-1ec398478ddb.png">

After:

<img width="1005" alt="Screenshot 2020-10-30 at 09 28 11" src="https://user-images.githubusercontent.com/112310/97688824-a1617c00-1a92-11eb-84be-0c3d3958335f.png">
 