### PR TITLE
Update 5.3 release post description

### DIFF
--- a/Content/posts/5-3-released.md
+++ b/Content/posts/5-3-released.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-11-10 0:39
-description: The first stable toolchain release of SwiftWasm!
+description: Our stable 5.3 release of the toolchain is now available
 ---
 
 # The first stable toolchain release of SwiftWasm!


### PR DESCRIPTION
Identical title and description currently look weird in the list of posts.

<img width="882" alt="Screenshot 2020-11-10 at 14 40 14" src="https://user-images.githubusercontent.com/112310/98688336-a6f87500-2362-11eb-968d-481f8932e4df.png">
